### PR TITLE
Fixed prefix randomization

### DIFF
--- a/nuid.go
+++ b/nuid.go
@@ -108,7 +108,7 @@ func (n *NUID) RandomizePrefix() {
 		panic(fmt.Sprintf("nuid: failed generating crypto random number: %v\n", err))
 	}
 	i := len(n.pre)
-	for l := r.Int64(); l > 0; l /= base {
+	for l := r.Int64(); i > 0; l /= base {
 		i -= 1
 		n.pre[i] = digits[l%base]
 	}

--- a/nuid_test.go
+++ b/nuid_test.go
@@ -34,6 +34,29 @@ func TestGUIDLen(t *testing.T) {
 	}
 }
 
+func TestProperPrefix(t *testing.T) {
+	min := byte(255)
+	max := byte(0)
+	for i := 0; i < len(digits); i++ {
+		if digits[i] < min {
+			min = digits[i]
+		}
+		if digits[i] > max {
+			max = digits[i]
+		}
+	}
+	total := 100000
+	for i := 0; i < total; i++ {
+		n := New()
+		for j := 0; j < preLen; j++ {
+			if n.pre[j] < min || n.pre[j] > max {
+				t.Fatalf("Iter %d. Valid range for bytes prefix: [%d..%d]\nIncorrect prefix at pos %d: %v (%s)",
+					i, min, max, j, n.pre, string(n.pre))
+			}
+		}
+	}
+}
+
 func BenchmarkNUIDSpeed(b *testing.B) {
 	n := New()
 	b.ReportAllocs()


### PR DESCRIPTION
-The loop was incorrectly using 'l' instead of 'i'.
-Added test that ensure that prefix is correctly set.

Resolves issue #3 (https://github.com/nats-io/nuid/issues/3)
