### PR TITLE
Travis-ci: added support for ppc64le & updated go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: go
 sudo: false
+arch:
+- amd64
+- ppc64le
 go:
-- 1.9.x
-- 1.10.x
+- 1.13.x
+- 1.14.x
 
 install:
 - go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ arch:
 - amd64
 - ppc64le
 go:
-- 1.13.x
 - 1.14.x
+- 1.15.x
 
 install:
 - go get -t ./...


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra